### PR TITLE
bugfix: fixing possible loading of client-only types for overridden and

### DIFF
--- a/src/main/java/su/sergiusonesimus/metaworlds/util/BlockVolatilityMap.java
+++ b/src/main/java/su/sergiusonesimus/metaworlds/util/BlockVolatilityMap.java
@@ -52,6 +52,8 @@ public class BlockVolatilityMap {
 
     public static boolean checkBlockVolatility(Block block) {
         int blockId = Block.getIdFromBlock(block);
+        ensureCapacity(blockId);
+
         if (!initializedBlocks[blockId]) {
             if (MetaworldsMod.isForgeMultipartLoaded && ForgeMultipartIntegration.isBlockMultipart(block)) {
                 return true;
@@ -66,9 +68,7 @@ public class BlockVolatilityMap {
                     BlockDummyReobfTracker.onNeighborBlockChange,
                     ON_NEIGHBOR_BLOCK_CHANGE_DESCRIPTOR);
             boolean isVolatile = overridesCanBlockStay || overridesOnNeighborBlockChange;
-
-
-            ensureCapacity(blockId);
+            
             volatileBlocksFlags[blockId] = isVolatile;
             initializedBlocks[blockId] = true;
         }

--- a/src/main/java/su/sergiusonesimus/metaworlds/util/BlockVolatilityMap.java
+++ b/src/main/java/su/sergiusonesimus/metaworlds/util/BlockVolatilityMap.java
@@ -13,13 +13,19 @@ import su.sergiusonesimus.metaworlds.block.BlockDummyReobfTracker;
 import su.sergiusonesimus.metaworlds.integrations.ForgeMultipartIntegration;
 
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.TreeMap;
 
 public class BlockVolatilityMap {
 
-    private static final Map<Integer, Boolean> blockVolatilityMap = new TreeMap<>();
+    /**
+     * 4096 is default Forge max id for blocks. If any id-extending mod is used this case is covered by
+     * calling {@link #ensureCapacity(int)} in {@link #checkBlockVolatility(Block)}
+     * In future we can switch from storing 8 blocks per 1 byte in an underlying array for 8x compression,
+     * but now memory difference is negligible (64Kb vs 8Kb)
+     */
+    private static boolean[] volatileBlocksFlags = new boolean[4096];
+    private static boolean[] initializedBlocks = new boolean[4096];
 
     // Method descriptors for the two Block methods we inspect
     private static final String CAN_BLOCK_STAY_DESCRIPTOR =
@@ -31,32 +37,42 @@ public class BlockVolatilityMap {
     public static void init() {
         Iterator<Block> iterator = ((FMLControlledNamespacedRegistry<Block>) Block.blockRegistry).typeSafeIterable()
                 .iterator();
+        int maxId = 0;
+        while (iterator.hasNext()) {
+            Block block = iterator.next();
+            int id = Block.getIdFromBlock(block);
+            if (id > maxId) maxId = id;
+        }
+        volatileBlocksFlags = new boolean[maxId + 1];
+        initializedBlocks = new boolean[maxId + 1];
+
+        iterator = ((FMLControlledNamespacedRegistry<Block>) Block.blockRegistry).typeSafeIterable().iterator();
         while (iterator.hasNext()) checkBlockVolatility(iterator.next());
     }
 
     public static boolean checkBlockVolatility(Block block) {
         int blockId = Block.getIdFromBlock(block);
-        Boolean isVolatile = blockVolatilityMap.get(blockId);
-        if (isVolatile != null) {
-            return isVolatile;
+        if (!initializedBlocks[blockId]) {
+            if (MetaworldsMod.isForgeMultipartLoaded && ForgeMultipartIntegration.isBlockMultipart(block)) {
+                return true;
+            }
+
+            boolean overridesCanBlockStay = overridesInSubclass(
+                    block.getClass(),
+                    BlockDummyReobfTracker.canBlockStayMethodName,
+                    CAN_BLOCK_STAY_DESCRIPTOR);
+            boolean overridesOnNeighborBlockChange = overridesInSubclass(
+                    block.getClass(),
+                    BlockDummyReobfTracker.onNeighborBlockChange,
+                    ON_NEIGHBOR_BLOCK_CHANGE_DESCRIPTOR);
+            boolean isVolatile = overridesCanBlockStay || overridesOnNeighborBlockChange;
+
+
+            ensureCapacity(blockId);
+            volatileBlocksFlags[blockId] = isVolatile;
+            initializedBlocks[blockId] = true;
         }
-
-        if (MetaworldsMod.isForgeMultipartLoaded && ForgeMultipartIntegration.isBlockMultipart(block)) {
-            return true;
-        }
-
-        boolean overridesCanBlockStay = overridesInSubclass(
-                block.getClass(),
-                BlockDummyReobfTracker.canBlockStayMethodName,
-                CAN_BLOCK_STAY_DESCRIPTOR);
-        boolean overridesOnNeighborBlockChange = overridesInSubclass(
-                block.getClass(),
-                BlockDummyReobfTracker.onNeighborBlockChange,
-                ON_NEIGHBOR_BLOCK_CHANGE_DESCRIPTOR);
-        isVolatile = overridesCanBlockStay || overridesOnNeighborBlockChange;
-
-        blockVolatilityMap.put(blockId, isVolatile);
-        return isVolatile;
+        return volatileBlocksFlags[blockId];
     }
 
     private static boolean overridesInSubclass(Class<?> cls, String methodName, String methodDescriptor) {
@@ -106,5 +122,13 @@ public class BlockVolatilityMap {
             if (block.isSideSolid(world, x, y, z, dir)) return true;
         }
         return false;
+    }
+
+    private static void ensureCapacity(int blockId) {
+        if (blockId >= volatileBlocksFlags.length) {
+            int newSize = Math.max(blockId + 1, volatileBlocksFlags.length * 2);
+            volatileBlocksFlags = Arrays.copyOf(volatileBlocksFlags, newSize);
+            initializedBlocks = Arrays.copyOf(initializedBlocks, newSize);
+        }
     }
 }

--- a/src/main/java/su/sergiusonesimus/metaworlds/util/BlockVolatilityMap.java
+++ b/src/main/java/su/sergiusonesimus/metaworlds/util/BlockVolatilityMap.java
@@ -1,62 +1,104 @@
 package su.sergiusonesimus.metaworlds.util;
 
-import java.util.Iterator;
-import java.util.Map;
-import java.util.TreeMap;
-
+import cpw.mods.fml.common.registry.FMLControlledNamespacedRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
-
-import cpw.mods.fml.common.registry.FMLControlledNamespacedRegistry;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import su.sergiusonesimus.metaworlds.MetaworldsMod;
 import su.sergiusonesimus.metaworlds.block.BlockDummyReobfTracker;
 import su.sergiusonesimus.metaworlds.integrations.ForgeMultipartIntegration;
 
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+
 public class BlockVolatilityMap {
 
-    private static Map<Integer, Boolean> blockVolatilityMap = new TreeMap<Integer, Boolean>();
+    private static final Map<Integer, Boolean> blockVolatilityMap = new TreeMap<>();
+
+    // Method descriptors for the two Block methods we inspect
+    private static final String CAN_BLOCK_STAY_DESCRIPTOR =
+            "(Lnet/minecraft/world/World;III)Z";
+    private static final String ON_NEIGHBOR_BLOCK_CHANGE_DESCRIPTOR =
+            "(Lnet/minecraft/world/World;IIILnet/minecraft/block/Block;)V";
 
     @SuppressWarnings("unchecked")
     public static void init() {
         Iterator<Block> iterator = ((FMLControlledNamespacedRegistry<Block>) Block.blockRegistry).typeSafeIterable()
-            .iterator();
+                .iterator();
         while (iterator.hasNext()) checkBlockVolatility(iterator.next());
     }
 
     public static boolean checkBlockVolatility(Block block) {
         int blockId = Block.getIdFromBlock(block);
-        Boolean isVolatile = (Boolean) blockVolatilityMap.get(Integer.valueOf(blockId));
-        if (isVolatile == null) {
-            if (MetaworldsMod.isForgeMultipartLoaded && ForgeMultipartIntegration.isBlockMultipart(block)) {
-                isVolatile = true;
-            } else {
-                try {
-                    if (block.getClass()
-                        .getMethod(
-                            BlockDummyReobfTracker.canBlockStayMethodName,
-                            new Class[] { World.class, Integer.TYPE, Integer.TYPE, Integer.TYPE })
-                        .getDeclaringClass()
-                        .equals(Block.class)
-                        && block.getClass()
-                            .getMethod(
-                                BlockDummyReobfTracker.onNeighborBlockChange,
-                                new Class[] { World.class, Integer.TYPE, Integer.TYPE, Integer.TYPE, Block.class })
-                            .getDeclaringClass()
-                            .equals(Block.class)) {
-                        isVolatile = false;
-                    } else {
-                        isVolatile = true;
-                    }
-                } catch (Exception e) {
-
-                }
-            }
-
-            blockVolatilityMap.put(Integer.valueOf(blockId), isVolatile);
+        Boolean isVolatile = blockVolatilityMap.get(blockId);
+        if (isVolatile != null) {
+            return isVolatile;
         }
+
+        if (MetaworldsMod.isForgeMultipartLoaded && ForgeMultipartIntegration.isBlockMultipart(block)) {
+            return true;
+        }
+
+        boolean overridesCanBlockStay = overridesInSubclass(
+                block.getClass(),
+                BlockDummyReobfTracker.canBlockStayMethodName,
+                CAN_BLOCK_STAY_DESCRIPTOR);
+        boolean overridesOnNeighborBlockChange = overridesInSubclass(
+                block.getClass(),
+                BlockDummyReobfTracker.onNeighborBlockChange,
+                ON_NEIGHBOR_BLOCK_CHANGE_DESCRIPTOR);
+        isVolatile = overridesCanBlockStay || overridesOnNeighborBlockChange;
+
+        blockVolatilityMap.put(blockId, isVolatile);
         return isVolatile;
+    }
+
+    private static boolean overridesInSubclass(Class<?> cls, String methodName, String methodDescriptor) {
+        Class<?> cur = cls;
+        while (cur != null && cur != Block.class && cur != Object.class) {
+            if (declaresMethod(cur, methodName, methodDescriptor)) return true;
+            cur = cur.getSuperclass();
+        }
+        return false;
+    }
+
+    private static boolean declaresMethod(Class<?> cls, final String methodName, final String methodDescriptor) {
+        ClassLoader loader = cls.getClassLoader();
+        if (loader == null) return false;
+        String resourceName = cls.getName().replace('.', '/') + ".class";
+
+        try (InputStream in = loader.getResourceAsStream(resourceName);) {
+            try {
+                if (in == null) return false;
+                ClassReader reader = new ClassReader(in);
+                final boolean[] found = new boolean[]{false};
+                // Currently using ASM5 since almost all 1.7.10 mods targeting Java 8. If higher versions are used,
+                // we'll need to bump to ASM9, but at first increase project target version
+                // Project's Gradle plugin (gtnhconvention) also targets 1.8 by default
+                // https://github.com/GTNewHorizons/GTNHGradle/blob/master/src/main/java/com/gtnewhorizons/gtnhgradle/modules/IdeIntegrationModule.java#L61
+                reader.accept(new ClassVisitor(Opcodes.ASM5) {
+                    @Override
+                    public MethodVisitor visitMethod(int access, String name, String desc,
+                                                     String signature, String[] exceptions) {
+                        if (!found[0] && methodName.equals(name) && methodDescriptor.equals(desc)) {
+                            found[0] = true;
+                        }
+                        return null;
+                    }
+                }, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+                return found[0];
+            } catch (Exception e) {
+                return false;
+            }
+        } catch (Exception ignored) {
+            return false;
+        }
     }
 
     public static boolean isBlockSolid(Block block, IBlockAccess world, int x, int y, int z) {
@@ -65,5 +107,4 @@ public class BlockVolatilityMap {
         }
         return false;
     }
-
 }


### PR DESCRIPTION
Hi! 
I'm very impressed with you work done to make such a promising mod (hope I'll have a time to contribute since I'm going to use it in one modpack) 
Currently there's an issue with running server that has this mod 
What do I mean
[Here](https://github.com/Gordon-Frohman/Metaworlds-Mixins/blob/main/src/main/java/su/sergiusonesimus/metaworlds/util/BlockVolatilityMap.java#L37) you try to check if block's class, that has two declared methods, equals to `Block.class`
```java
                    block.getClass()
                        .getMethod(
                            BlockDummyReobfTracker.canBlockStayMethodName,
                            new Class[] { World.class, Integer.TYPE, Integer.TYPE, Integer.TYPE })
                        .getDeclaringClass()
                        .equals(Block.class)
```
And all is fine on client side due to `@SideOnly(Side.SERVER)` is used rarely in mods 
But when you start dedicated server `cpw.mods.fml.common.asm.transformers.SideTransformer` strips out everything that is annotated with `@SideOnly(Side.CLIENT)` - and such interface is `net/minecraft/client/renderer/texture/IIconRegister`. It is referenced in the `Block` class (together with other classes) as 
```java
    @SideOnly(Side.CLIENT)
    public void registerBlockIcons(IIconRegister p_149651_1_)
    {
        this.blockIcon = p_149651_1_.registerIcon(this.getTextureName());
    }
```
But your code - `block.getClass().getMethod` internally calls `getDeclaredMethods`, what leads to leading all declared methods - and their signature classes loading into JVM. Some mods overide client-only methods, but do not mark them `@SideOnly(Side.CLIENT)` => they are not stripped and we get a crash - for example, IC2:

## `industrialcraft-2-2.2.828-experimental.jar`

| Class                                      | Missing annotation on                  |
|--------------------------------------------|----------------------------------------|
| `ic2/core/block/BlockBarrel`               | `getTextureName`                       |
| `ic2/core/block/BlockBase`                 | `getTextureName`, `registerBlockIcons` |
| `ic2/core/block/BlockIC2Door`              | `registerBlockIcons`                   |
| `ic2/core/block/BlockIC2Fluid`             | `registerBlockIcons`                   |
| `ic2/core/block/BlockMetaData`             | `getTextureName`, `registerBlockIcons` |
| `ic2/core/block/BlockMultiID`              | `getTextureName`, `registerBlockIcons` |
| `ic2/core/block/BlockRubLeaves`            | `registerBlockIcons`                   |
| `ic2/core/block/BlockRubSapling`           | `registerBlockIcons`                   |
| `ic2/core/block/BlockRubWood`              | `getTextureName`                       |
| `ic2/core/block/BlockScaffold`             | `getTextureName`                       |
| `ic2/core/block/BlockWall`                 | `getTextureName`                       |
| `ic2/core/block/wiring/BlockCable`         | `getTextureName`, `registerBlockIcons` |
| `ic2/core/crop/BlockCrop`                  | `getTextureName`, `registerBlockIcons` |
| `ic2/core/item/ItemBattery`                | `getTextureName`                       |
| `ic2/core/item/ItemBatteryDischarged`      | `getTextureName`                       |
| `ic2/core/item/ItemBooze`                  | `getTextureName`                       |
| `ic2/core/item/ItemFluidCell`              | `getTextureName`                       |
| `ic2/core/item/ItemIC2`                    | `getTextureName`                       |
| `ic2/core/item/ItemUpgradeModule`          | `getTextureName`                       |
| `ic2/core/item/resources/ItemLatheDefault` | `getTextureName`                       |

So I've rewrote your logic that checks for given methods existance somewhere in a class tree using ASM - it doesn't trigged signature class lookup 
Can you please review 