### PR TITLE
Wrapping client-bound code execution in common (client/server) methods in a side check

### DIFF
--- a/src/main/java/su/sergiusonesimus/metaworlds/MWControlEventListener.java
+++ b/src/main/java/su/sergiusonesimus/metaworlds/MWControlEventListener.java
@@ -19,7 +19,7 @@ public class MWControlEventListener {
         // if (event.player.worldBelowFeet instanceof SubWorld) {
         // SubWorld world = (SubWorld)event.player.worldBelowFeet;
         // }
-        if (BlockSubWorldController.toMakeFalse && count > 10) {
+        if (event.side.isClient() && BlockSubWorldController.toMakeFalse && count > 10) {
             KeyBinding.setKeyBindState(Minecraft.getMinecraft().gameSettings.keyBindSneak.getKeyCode(), false);
             BlockSubWorldController.toMakeFalse = false;
             count = 0;

--- a/src/main/java/su/sergiusonesimus/metaworlds/block/BlockContagiousSubWorldCreator.java
+++ b/src/main/java/su/sergiusonesimus/metaworlds/block/BlockContagiousSubWorldCreator.java
@@ -10,7 +10,6 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.ChunkCoordinates;
-import net.minecraft.util.MathHelper;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.World;
@@ -191,8 +190,8 @@ public class BlockContagiousSubWorldCreator extends Block {
                                 blockList.add(newCoords);
                             }
                             ChunkCoordIntPair newChunk = new ChunkCoordIntPair(
-                                MathHelper.bucketInt(newCoords.posX, 16),
-                                MathHelper.bucketInt(newCoords.posZ, 16));
+                                newCoords.posX >> 4,
+                                newCoords.posZ >> 4);
                             Integer blocksCount = blocksInChunks.get(newChunk);
                             if (blocksCount == null) {
                                 blocksCount = 1;

--- a/src/main/java/su/sergiusonesimus/metaworlds/block/BlockSubWorldController.java
+++ b/src/main/java/su/sergiusonesimus/metaworlds/block/BlockSubWorldController.java
@@ -24,7 +24,7 @@ public class BlockSubWorldController extends Block {
 
     public boolean onBlockActivated(World par1World, int par2, int par3, int par4, EntityPlayer par5EntityPlayer,
         int par6, float par7, float par8, float par9) {
-        if (par5EntityPlayer.ridingEntity instanceof EntitySubWorldController) {
+        if (par1World.isRemote && par5EntityPlayer.ridingEntity instanceof EntitySubWorldController) {
             par5EntityPlayer.dismountEntity(par5EntityPlayer.ridingEntity);
             par5EntityPlayer.ridingEntity.setDead();
             par5EntityPlayer.ridingEntity = null;
@@ -32,6 +32,7 @@ public class BlockSubWorldController extends Block {
             toMakeFalse = true;
             return true;
         }
+
         if (par1World.isRemote) {
             return true;
         } else {


### PR DESCRIPTION
Wrapping client-bound code execution in common (client/server) methods in a side check
Removing usage of client-only code in a server part (`expandAtMargin`)